### PR TITLE
Implement Generic Types for Querying Models

### DIFF
--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -3,7 +3,7 @@ import { User } from '../models/User';
 import { HttpStatusCode, LoginRequest } from '../types';
 import { sendAuthTokens } from '../middleware/jwts';
 import { LoginError } from '../errors/application-errors/login-error';
-import { IUser } from '../types/schemas';
+import { SuccessfulQuery, IUser } from '../types/schemas';
 import { compare } from 'bcrypt';
 import { InternalApiError } from '../errors/internalApiError';
 import { MongoError } from '../errors/mongo-error';
@@ -27,8 +27,8 @@ function getLoginVariables(req: Request): LoginRequest {
  * returns that user if so
  */
 
-async function checkIfUserExists(username: string): Promise<IUser> {
-  let { user, error } = await User.findByUsername(username);
+async function checkIfUserExists(username: string): Promise<SuccessfulQuery<IUser>> {
+  let { data, error } = await User.findByUsername(username);
   if (error) {
     throw new MongoError({
       name: 'FAILED_TO_LOOK_UP_EXISTING_USER',
@@ -36,14 +36,14 @@ async function checkIfUserExists(username: string): Promise<IUser> {
       stack: error,
     });
   }
-  if (user === null) {
+  if (data === null) {
     throw new LoginError({
       name: 'NON_EXISTENT_USER',
       message: `No user exists with given username ${username}`,
       level: 'Info',
     });
   }
-  return user;
+  return data;
 }
 
 /*

--- a/src/controllers/login.ts
+++ b/src/controllers/login.ts
@@ -3,7 +3,6 @@ import { User } from '../models/User';
 import { HttpStatusCode, LoginRequest } from '../types';
 import { sendAuthTokens } from '../middleware/jwts';
 import { LoginError } from '../errors/application-errors/login-error';
-import { SuccessfulQuery, IUser } from '../types/schemas';
 import { compare } from 'bcrypt';
 import { InternalApiError } from '../errors/internalApiError';
 import { MongoError } from '../errors/mongo-error';
@@ -27,7 +26,7 @@ function getLoginVariables(req: Request): LoginRequest {
  * returns that user if so
  */
 
-async function checkIfUserExists(username: string): Promise<SuccessfulQuery<IUser>> {
+async function checkIfUserExists(username: string): Promise<User> {
   let { data, error } = await User.findByUsername(username);
   if (error) {
     throw new MongoError({

--- a/src/controllers/signup.ts
+++ b/src/controllers/signup.ts
@@ -5,7 +5,6 @@ import { MongoError } from '../errors/mongo-error';
 import { genSalt, hash } from 'bcrypt';
 import { HttpStatusCode, SignUpRequest } from '../types';
 import { v4 as uuidv4 } from 'uuid';
-import { IUser } from '../types/schemas';
 import { InternalApiError } from '../errors/internalApiError';
 import { sendAuthTokens } from '../middleware/jwts';
 

--- a/src/controllers/signup.ts
+++ b/src/controllers/signup.ts
@@ -50,7 +50,7 @@ async function checkIfUserExists(
   username: string,
   email: string,
 ): Promise<void> {
-  let { user, error } = await User.findByEmailOrUsername(username, email);
+  let { data, error } = await User.findByEmailOrUsername(username, email);
   if (error) {
     throw new MongoError({
       name: 'FAILED_TO_LOOK_UP_EXISTING_USER',
@@ -58,20 +58,20 @@ async function checkIfUserExists(
       stack: error,
     });
   }
-  if (user) {
-    if (user.username === username && user.email === email) {
+  if (data) {
+    if (data.username === username && data.email === email) {
       throw new SignUpError({
         name: 'USERNAME_AND_EMAIL_IN_USE',
         message: 'Username and email in use by an existing user',
         level: 'Info',
       });
-    } else if (user.username === username) {
+    } else if (data.username === username) {
       throw new SignUpError({
         name: 'USERNAME_IN_USE',
         message: 'Username in use by an existing user',
         level: 'Info',
       });
-    } else if (user.email === email) {
+    } else if (data.email === email) {
       throw new SignUpError({
         name: 'EMAIL_IN_USE',
         message: 'Email in use by an existing user',

--- a/src/middleware/jwts.ts
+++ b/src/middleware/jwts.ts
@@ -147,22 +147,22 @@ export async function checkTokens(
     });
   }
   let refreshTokenData = verifyRefreshToken(refreshToken);
-  let { user, error } = await User.findByUsername(refreshTokenData.username);
-  if (user === null) {
+  let { data, error } = await User.findByUsername(refreshTokenData.username);
+  if (data === null) {
     throw new AuthError({
       name: 'USER_NOT_FOUND_FROM_REFRESH',
       message: 'Unable to find user with username supplied via refresh token',
     });
-  } else if (refreshTokenData.refreshTokenVersion !== user.refreshToken) {
+  } else if (refreshTokenData.refreshTokenVersion !== data.refreshToken) {
     throw new AuthError({
       name: 'REFRESH_TOKEN_VERSION_MISMATCH',
       message: 'User has supplied an outdated refresh token',
     });
   }
-  sendAuthTokens(res, user);
+  sendAuthTokens(res, data);
   return {
-    username: user.username,
-    user,
+    username: data.username,
+    user: data,
   };
 }
 

--- a/src/middleware/jwts.ts
+++ b/src/middleware/jwts.ts
@@ -2,7 +2,6 @@
 import { __prod__ } from '../utils/constants';
 import { NextFunction, Request, Response } from 'express';
 import { User } from '../models/User';
-import { IUser } from '../types/schemas';
 import {
   RefreshTokenData,
   AccessTokenData,
@@ -11,7 +10,6 @@ import {
 } from '../types';
 import { AuthError } from '../errors/authError';
 import * as jwt from 'jsonwebtoken';
-import { InternalApiError } from '../errors/internalApiError';
 
 const cookieOpts = {
   httpOnly: true,
@@ -22,18 +20,7 @@ const cookieOpts = {
   maxAge: 1000 * 60 * 60 * 24 * 365, // 1 year
 } as const;
 
-function getUserProperty(req: Request): IUser {
-  if (req.user === undefined) {
-    throw new InternalApiError({
-      name: 'REQUEST_OBJECT_MISSING_PROPERTY',
-      message:
-        'User object missing from request object when attempting to sign jwts',
-    });
-  }
-  return req.user;
-}
-
-function createAuthTokens(user: IUser): NewlyGeneratedTokens {
+function createAuthTokens(user: User): NewlyGeneratedTokens {
   let refreshToken = jwt.sign(
     { username: user.username, refreshTokenVersion: user.refreshToken },
     process.env.REFRESH_TOKEN_SECRET,
@@ -65,7 +52,7 @@ export function getCookieValues(req: Request) {
   return { accessToken: id, refreshToken: rid };
 }
 
-export function sendAuthTokens(res: Response, user: IUser) {
+export function sendAuthTokens(res: Response, user: User) {
   let { accessToken, refreshToken } = createAuthTokens(user);
   res.cookie('id', accessToken, cookieOpts);
   res.cookie('rid', refreshToken, cookieOpts);

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,4 +1,4 @@
-import { MongoDocumentQuery } from '../types/schemas';
+import { DocumentQuery } from '../types/schemas';
 import { IUser } from '../types/schemas';
 import { UserModel } from './schemas/user';
 import { UserQueries } from './queries/user';
@@ -14,7 +14,7 @@ export class User extends UserModel {
     });
   }
 
-  static async findByUsername(username: string): Promise<MongoDocumentQuery<IUser>> {
+  static async findByUsername(username: string): Promise<DocumentQuery<User>> {
     try {
       let user = await UserQueries.queryByUsername(username);
       if (user !== null) {
@@ -29,7 +29,7 @@ export class User extends UserModel {
   static async findByEmailOrUsername(
     username: string,
     email: string,
-  ): Promise<MongoDocumentQuery<IUser>> {
+  ): Promise<DocumentQuery<User>> {
     try {
       let user = await UserQueries.queryByEmailOrUsername(username, email);
       if (user !== null) {

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,6 +1,6 @@
+import { MongoDocumentQuery } from '../types/schemas';
 import { IUser } from '../types/schemas';
 import { UserModel } from './schemas/user';
-import { UserQuery } from '../types';
 import { UserQueries } from './queries/user';
 
 export class User extends UserModel {
@@ -14,30 +14,30 @@ export class User extends UserModel {
     });
   }
 
-  static async findByUsername(username: string): Promise<UserQuery> {
+  static async findByUsername(username: string): Promise<MongoDocumentQuery<IUser>> {
     try {
       let user = await UserQueries.queryByUsername(username);
       if (user !== null) {
-        return { user, error: null };
+        return { data: user, error: null };
       }
-      return { user: null, error: null };
+      return { data: null, error: null };
     } catch (error) {
-      return { user: null, error };
+      return { data: null, error };
     }
   }
 
   static async findByEmailOrUsername(
     username: string,
     email: string,
-  ): Promise<UserQuery> {
+  ): Promise<MongoDocumentQuery<IUser>> {
     try {
       let user = await UserQueries.queryByEmailOrUsername(username, email);
       if (user !== null) {
-        return { user, error: null };
+        return { data: user, error: null };
       }
-      return { user: null, error: null };
+      return { data: null, error: null };
     } catch (error) {
-      return { user: null, error };
+      return { data: null, error };
     }
   }
 }

--- a/src/models/queries/user.ts
+++ b/src/models/queries/user.ts
@@ -1,24 +1,24 @@
-import { SuccessfulQuery } from '../../types/schemas';
+import { MDBDocument } from '../../types/schemas';
 import { UserModel } from '../schemas/user';
-import { IUser } from '../../types/schemas';
+import { User } from '../User';
 
 export class UserQueries extends UserModel {
   static async queryByEmailOrUsername(
     username: string,
     email: string,
-  ): Promise<SuccessfulQuery<IUser> | null> {
+  ): Promise<MDBDocument<User> | null> {
     return UserModel.findOne({
       $or: [{ username }, { email }],
     });
   }
 
-  static async queryByEmail(email: string): Promise<SuccessfulQuery<IUser> | null> {
+  static async queryByEmail(email: string): Promise<MDBDocument<User> | null> {
     return UserModel.findOne({
       email,
     });
   }
 
-  static async queryByUsername(username: string): Promise<SuccessfulQuery<IUser> | null> {
+  static async queryByUsername(username: string): Promise<MDBDocument<User> | null> {
     return UserModel.findOne({
       username: username,
     });

--- a/src/models/queries/user.ts
+++ b/src/models/queries/user.ts
@@ -1,3 +1,4 @@
+import { SuccessfulQuery } from '../../types/schemas';
 import { UserModel } from '../schemas/user';
 import { IUser } from '../../types/schemas';
 
@@ -5,19 +6,19 @@ export class UserQueries extends UserModel {
   static async queryByEmailOrUsername(
     username: string,
     email: string,
-  ): Promise<IUser | null> {
+  ): Promise<SuccessfulQuery<IUser> | null> {
     return UserModel.findOne({
       $or: [{ username }, { email }],
     });
   }
 
-  static async queryByEmail(email: string): Promise<IUser | null> {
+  static async queryByEmail(email: string): Promise<SuccessfulQuery<IUser> | null> {
     return UserModel.findOne({
       email,
     });
   }
 
-  static async queryByUsername(username: string): Promise<IUser | null> {
+  static async queryByUsername(username: string): Promise<SuccessfulQuery<IUser> | null> {
     return UserModel.findOne({
       username: username,
     });

--- a/src/models/schemas/bonsai.ts
+++ b/src/models/schemas/bonsai.ts
@@ -1,7 +1,7 @@
 import { Schema, model } from 'mongoose';
-import { Bonsai } from '../../types/schemas';
+import { IBonsai } from '../../types/schemas';
 
-const BonsaiSchema = new Schema<Bonsai>(
+const BonsaiSchema = new Schema<IBonsai>(
   {
     user: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     bonsaiChapters: [

--- a/src/models/schemas/bonsaiChapter.ts
+++ b/src/models/schemas/bonsaiChapter.ts
@@ -1,7 +1,7 @@
 import { Schema, model } from 'mongoose';
-import { BonsaiChapter } from '../../types/schemas';
+import { IBonsaiChapter } from '../../types/schemas';
 
-const BonsaiChapterSchema = new Schema<BonsaiChapter>(
+const BonsaiChapterSchema = new Schema<IBonsaiChapter>(
   {
     photoUrls: [{ type: Schema.Types.String, maxLength: 200, required: true }],
     bonsai: { type: Schema.Types.ObjectId, ref: 'Bonsai', required: true },

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -1,4 +1,4 @@
-import { Types } from 'mongoose';
+import { Types, Document } from 'mongoose';
 
 export interface IUser {
   username: string;
@@ -27,4 +27,11 @@ export interface IBonsaiChapter {
   bonsai: Types.ObjectId;
   date: Date;
   caption: string;
+}
+
+export type MDBDocument<T> = T | null
+
+export type DocumentQuery<T> = {
+  data: T | null
+  error: unknown
 }

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -11,7 +11,7 @@ export interface IUser {
   refreshToken: number;
 }
 
-export interface Bonsai {
+export interface IBonsai {
   user: Types.ObjectId;
   bonsaiChapters: Types.ObjectId[];
   hardiness_zone: string;
@@ -22,7 +22,7 @@ export interface Bonsai {
   species: string;
 }
 
-export interface BonsaiChapter {
+export interface IBonsaiChapter {
   photoUrls: string[];
   bonsai: Types.ObjectId;
   date: Date;

--- a/tests/test-functions.ts
+++ b/tests/test-functions.ts
@@ -43,11 +43,11 @@ export async function TEST_createUser(testUserData: TestUser): Promise<User> {
   ) {
     throw new Error('No test variables passed');
   }
-  let { user, error } = await User.findByEmailOrUsername(
+  let { data, error } = await User.findByEmailOrUsername(
     testUserData.username as string,
     testUserData.email as string,
   );
-  if (user) {
+  if (data) {
     throw new Error('User already exists in database');
   }
   let hashedPassword = await hash(testUserData.password, 12);


### PR DESCRIPTION
Addresses #16 

This PR adds Generic types for writing custom queries so that these types can be easily reused:

```typescript
// new types
export type MDBDocument<T> = T | null

export type DocumentQuery<T> = {
  data: T | null
  error: unknown
}
```

These will be used in User and other custom classes for extending Mongo Models when it comes to writing functions that query our database: 

```typescript
class User extends UserModel  {
// ...
static async findByUsername(username: string): Promise<DocumentQuery<User>> {
  try {
      let user = await UserQueries.queryByUsername(username);
      if (user !== null) {
        return { data: user, error: null };
      }
      return { data: null, error: null };
    } catch (error) {
      return { data: null, error };
    }
  } 
}
```

And in Queries:

```typescript
static async queryByUsername(username: string): Promise<MDBDocument<User> | null> {
  return UserModel.findOne({
    username: username,
  });
}
```

You'll notice that the type being passed in for both of these generic types is User. As you'll recall, we extend our User class with UserModel, which gives us access to all fields and methods provided by mongoose for handling MongoDB documents. This includes the ._id property generated by MongoDB at creation. We will follow the same pattern for implementing `Bonsai` and `BonsaiChapters` by passing in `MDBDocument<Bonsai>` or `MDBDocument<BonsaiChapter>`. 

This PR also changed any function that accepted an argument of type IUser or returned a value of type IUser. These functions have now being changed to accept arguments or return values of type User. Since User has all of the same properties of IUser, it had no real effect on these functions. 